### PR TITLE
Provide best possible email address

### DIFF
--- a/lib/omniauth/strategies/windowslive.rb
+++ b/lib/omniauth/strategies/windowslive.rb
@@ -27,6 +27,7 @@ module OmniAuth
       info do
         {
           'id' => raw_info['id'],
+          'email' => raw_info['emails']['preferred'] || raw_info['emails']['account'],
           'name' => raw_info['name'],
           'first_name' => raw_info['first_name'],
           'last_name' => raw_info['last_name'],

--- a/lib/omniauth/windowslive/version.rb
+++ b/lib/omniauth/windowslive/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Windowslive
-    VERSION = "0.0.8.1"
+    VERSION = "0.0.8.2"
   end
 end


### PR DESCRIPTION
Per the OmniAuth wiki:

`email` - The e-mail of the authenticating user. Should be provided if at all possible (but some sites such as Twitter do not provide this information)

Since the email is definitely available, it should be provided.  Defaults to preferred (which is optional), but will fallback to the account email (which is always available).
