### PR TITLE
Remove the querystring from the callback URL

### DIFF
--- a/lib/omniauth/strategies/windowslive.rb
+++ b/lib/omniauth/strategies/windowslive.rb
@@ -1,3 +1,4 @@
+require 'uri'
 require 'omniauth/strategies/oauth2'
 
 # http://msdn.microsoft.com/en-us/library/hh243647.aspx
@@ -51,6 +52,12 @@ module OmniAuth
       end
 
       private
+      
+      def build_access_token
+        verifier = request.params["code"]
+        redirect_uri = URI.parse(callback_url).tap { |uri| uri.query = nil }.to_s
+        client.auth_code.get_token(verifier, {:redirect_uri => redirect_uri}.merge(token_params.to_hash(:symbolize_keys => true)), deep_symbolize(options.auth_token_params))
+      end
 
       def emails_parser
         emails = raw_info['emails']


### PR DESCRIPTION
In the existing code, I get an error like this when authenticating:

```
Authentication failure! invalid_credentials: OAuth2::Error, invalid_grant: The provided value for the 'redirect_uri' is not valid. The value must exactly match the redirect URI used to obtain the authorization code.
```

Upon inspection, the callback URL which it was submitting when fetching the access token included the `?code=` portion. It looks like Windows Live doesn't like this - there are a few Google results about it.

This removes the query string before submitting.