### PR TITLE
add single `email` field to info hash

### DIFF
--- a/lib/omniauth/strategies/windowslive.rb
+++ b/lib/omniauth/strategies/windowslive.rb
@@ -29,7 +29,7 @@ module OmniAuth
         {
           'id'           => raw_info['id'],
           'emails'       => emails_parser,
-          'email'        => emails.find { |email| email['value'].to_s != '' }['value'],
+          'email'        => emails_parser.find { |email| email['value'].to_s != '' }['value'],
           'name'         => raw_info['name'],
           'first_name'   => raw_info['first_name'],
           'last_name'    => raw_info['last_name'],

--- a/lib/omniauth/strategies/windowslive.rb
+++ b/lib/omniauth/strategies/windowslive.rb
@@ -29,6 +29,7 @@ module OmniAuth
         {
           'id'           => raw_info['id'],
           'emails'       => emails_parser,
+          'email'        => emails.find { |email| email['value'].to_s != '' }['value'],
           'name'         => raw_info['name'],
           'first_name'   => raw_info['first_name'],
           'last_name'    => raw_info['last_name'],

--- a/spec/omniauth/strategies/windowslive_spec.rb
+++ b/spec/omniauth/strategies/windowslive_spec.rb
@@ -26,4 +26,12 @@ describe OmniAuth::Strategies::Windowslive do
       subject.callback_path.should eq('/auth/windowslive/callback')
     end
   end
+
+  describe '#email' do
+    it 'should provide email from emails hash' do
+      email = 'test@example.com'
+      subject.stub(:raw_info) { {'emails' => {'preferred' => email}} }
+      subject.info['email'].should eq(email)
+    end
+  end
 end


### PR DESCRIPTION
An extra singular `email` field is helpful for auto-populating email information on a model, e.g., via a Devise controller that works with multiple oauth integrations.
