### PR TITLE
Remove query parameters from `callback_url`

### DIFF
--- a/lib/omniauth/strategies/windowslive.rb
+++ b/lib/omniauth/strategies/windowslive.rb
@@ -52,11 +52,9 @@ module OmniAuth
       end
 
       private
-      
-      def build_access_token
-        verifier = request.params["code"]
-        redirect_uri = URI.parse(callback_url).tap { |uri| uri.query = nil }.to_s
-        client.auth_code.get_token(verifier, {:redirect_uri => redirect_uri}.merge(token_params.to_hash(:symbolize_keys => true)), deep_symbolize(options.auth_token_params))
+
+      def callback_url
+        URI.parse(super).tap { |uri| uri.query = nil }.to_s
       end
 
       def emails_parser

--- a/spec/omniauth/strategies/windowslive_spec.rb
+++ b/spec/omniauth/strategies/windowslive_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe OmniAuth::Strategies::Windowslive do
   subject do
-    OmniAuth::Strategies::Windowslive.new(nil, @options || {})
+    OmniAuth::Strategies::Windowslive.new(nil, @options || {}).tap do |strategy|
+      strategy.instance_variable_set(:@env, {})
+    end
   end
 
   it_should_behave_like 'an oauth2 strategy'
@@ -24,6 +26,13 @@ describe OmniAuth::Strategies::Windowslive do
   describe '#callback_path' do
     it 'should have the correct callback path' do
       subject.callback_path.should eq('/auth/windowslive/callback')
+    end
+  end
+
+  describe '#callback_url' do
+    it 'should remove query string from callback url' do
+      subject.stub(:query_string) {'?key=value'}
+      subject.send(:callback_url).should_not end_with(subject.query_string)
     end
   end
 end


### PR DESCRIPTION
Because query parameter removal is needed for `request_phase` in addition to `build_access_token`, this PR overrides the `callback_url` parameter instead of `build_access_token`.

Otherwise, the oauth check will fail with the following error if any query parameters are included in the redirected request:

> Authentication failure! invalid_credentials: OAuth2::Error, invalid_grant: The provided value for the 'redirect_uri' is not valid. The value must exactly match the redirect URI used to obtain the authorization code.
> {"error":"invalid_grant","error_description":"The provided value for the 'redirect_uri' is not valid. The value must exactly match the redirect URI used to obtain the authorization code."}
